### PR TITLE
Add Docker support for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+venv
+.venv
+node_modules
+web-ui/node_modules
+data/vectors
+data/pdfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    poppler-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8001
+
+CMD ["python", "run_api.py"]

--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ jupyter notebook
 ```
 Open `notebooks/experiments/updated_rag_notebook.ipynb` to experiment with the code.
 
+## Docker
+
+You can run the FastAPI backend inside Docker for a more consistent setup.
+
+### Prerequisites
+- Docker installed on your machine
+- Ollama running locally and accessible from the container
+
+### Build the image
+
+```bash
+docker build -t ollama-pdf-rag-api .
+
 ## 💡 Usage
 
 ### Next.js Interface


### PR DESCRIPTION
## Summary
Adds Docker support for the FastAPI backend.

## Changes
- Added `Dockerfile`
- Added `.dockerignore`
- Updated `README.md` with build and run instructions

## Related issue
Closes https://github.com/tonykipkemboi/ollama_pdf_rag/issues/60