### PR TITLE
Update README.md

### DIFF
--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -26,7 +26,7 @@ A modern Next.js frontend for chatting with your PDF documents locally using Oll
 ```bash
 pnpm install
 ```
-2.Set up environment variable
+2. Set up environment variables:
 ```bash
 cp .env.example .env
 ```

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -26,13 +26,16 @@ A modern Next.js frontend for chatting with your PDF documents locally using Oll
 ```bash
 pnpm install
 ```
-
-2. Set up the database:
+2.Set up environment variable
+```bash
+cp .env.example .env
+```
+3. Set up the database:
 ```bash
 pnpm db:migrate
 ```
 
-3. Start the development server:
+4. Start the development server:
 ```bash
 pnpm dev
 ```


### PR DESCRIPTION
This PR resolves an immediate setup failure during the local frontend configuration. Previously, the instructions skipped from dependency installation straight to running database migrations (`pnpm db:migrate`), which throws an error because the configuration relies on environment variables that haven't been initialized yet. fix-proposed-:
Added step `2. Set up environment variables` to explicitly instruct users to copy `.env.example` to `.env` before migrating.